### PR TITLE
🔀 :: 정규표현식 안되는 이슈 해결

### DIFF
--- a/account/src/main/kotlin/com/indistraw/account/adapter/input/request/SignUpRequest.kt
+++ b/account/src/main/kotlin/com/indistraw/account/adapter/input/request/SignUpRequest.kt
@@ -1,7 +1,6 @@
 package com.indistraw.account.adapter.input.request
 
 import org.hibernate.validator.constraints.Length
-import javax.validation.constraints.Max
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Pattern
 import javax.validation.constraints.Size
@@ -13,7 +12,7 @@ data class SignUpRequest(
 
     @field:NotNull
     @field:Length(min = 8, max = 20)
-    @field:Pattern(regexp = "[0-9a-zA-Z]{0,20}")
+    @field:Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])[0-9a-zA-Z]+$")
     val password: String,
 
     @field:NotNull


### PR DESCRIPTION
## 💡 개요
- 비밀번호 숫자 & 영어가 한번이라도 들어가야 하는 정규표현식 적용 안되는 이슈 해결

## 📃 작업사항
## 🙋‍♂️ 리뷰내용
