### PR TITLE
🔀 :: 클라우드 타입 배포 안되는 이슈 해결

### DIFF
--- a/account/src/main/kotlin/com/project/indistraw/account/adapter/input/converter/AccountDataConverter.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/adapter/input/converter/AccountDataConverter.kt
@@ -1,0 +1,26 @@
+package com.project.indistraw.account.adapter.input.converter
+
+import com.project.indistraw.account.adapter.input.request.UpdatePasswordRequest
+import com.project.indistraw.account.adapter.input.request.UpdateAccountProfileRequest
+import com.project.indistraw.account.application.port.input.dto.UpdateAccountProfileDto
+import com.project.indistraw.account.application.port.input.dto.UpdatePasswordDto
+import org.springframework.stereotype.Component
+
+@Component
+class AccountDataConverter {
+
+    infix fun toDto(request: UpdatePasswordRequest): UpdatePasswordDto =
+        UpdatePasswordDto(
+            phoneNumber = request.phoneNumber,
+            newPassword = request.newPassword
+        )
+
+    infix fun toDto(request: UpdateAccountProfileRequest): UpdateAccountProfileDto =
+        UpdateAccountProfileDto(
+            name = request.name,
+            phoneNumber = request.phoneNumber,
+            address = request.address,
+            profileUrl = request.profileUrl
+        )
+
+}


### PR DESCRIPTION
## 💡 개요
- 클라우드 타입 배포 안되는 이슈를 해결하였습니다.
## 📃 작업사항
- accountWebAdapter에서 accountDataConver를 의존하고 있었는데 커밋하는것을 깜빡하여 생긴 이슈를 해결하였습니다.
## 🙋‍♂️ 리뷰내용
