### PR TITLE
🔀  :: 인증코드 확인 요청 5번 초과시 예외처리 로직 추가

### DIFF
--- a/account/src/main/kotlin/com/project/indistraw/IndistrawAccountApplication.kt
+++ b/account/src/main/kotlin/com/project/indistraw/IndistrawAccountApplication.kt
@@ -4,12 +4,14 @@ import mu.KotlinLogging
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
 import java.time.LocalDateTime
 import java.util.*
 import javax.annotation.PostConstruct
 
 private val log = KotlinLogging.logger {  }
 
+@EnableAsync
 @ConfigurationPropertiesScan
 @SpringBootApplication
 class IndistrawAccountApplication {

--- a/account/src/main/kotlin/com/project/indistraw/account/adapter/output/message/CoolSmsAdapter.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/adapter/output/message/CoolSmsAdapter.kt
@@ -4,6 +4,7 @@ import com.project.indistraw.account.adapter.output.message.properties.CoolSmsPr
 import com.project.indistraw.account.application.port.output.SendMessagePort
 import net.nurigo.java_sdk.api.Message
 import net.nurigo.java_sdk.exceptions.CoolsmsException
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 
 
@@ -12,6 +13,7 @@ class CoolSmsAdapter(
     private val coolSmsProperties: CoolSmsProperties
 ): SendMessagePort {
 
+    @Async
     override fun sendMessage(phoneNumber: String, authCode: Int) {
         val coolsms = Message(coolSmsProperties.access, coolSmsProperties.secret)
 

--- a/account/src/main/kotlin/com/project/indistraw/account/adapter/output/persistence/QueryAuthenticationPersistenceAdapter.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/adapter/output/persistence/QueryAuthenticationPersistenceAdapter.kt
@@ -18,4 +18,8 @@ class QueryAuthenticationPersistenceAdapter(
         return authenticationConverter toDomain authenticationEntity
     }
 
+    override fun existsByPhoneNumber(phoneNumber: String): Boolean {
+        return authenticationRepository.existsById(phoneNumber)
+    }
+
 }

--- a/account/src/main/kotlin/com/project/indistraw/account/adapter/output/persistence/common/converter/AuthenticationConverter.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/adapter/output/persistence/common/converter/AuthenticationConverter.kt
@@ -11,7 +11,8 @@ class AuthenticationConverter {
         domain.let {
             AuthenticationEntity(
                 phoneNumber = it.phoneNumber,
-                attemptCount = it.attemptCount,
+                authCodeCount = it.authCodeCount,
+                authenticationCount = it.authenticationCount,
                 isVerified = it.isVerified,
                 expiredAt = it.expiredAt
             )
@@ -21,7 +22,8 @@ class AuthenticationConverter {
         entity?.let {
             Authentication(
                 phoneNumber = it.phoneNumber,
-                attemptCount = it.attemptCount,
+                authCodeCount = it.authCodeCount,
+                authenticationCount = it.authenticationCount,
                 isVerified = it.isVerified,
                 expiredAt = it.expiredAt
             )

--- a/account/src/main/kotlin/com/project/indistraw/account/adapter/output/persistence/entity/AuthenticationEntity.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/adapter/output/persistence/entity/AuthenticationEntity.kt
@@ -11,7 +11,9 @@ data class AuthenticationEntity(
     @Id
     val phoneNumber: String,
 
-    val attemptCount: Long,
+    val authCodeCount: Long,
+
+    val authenticationCount: Long,
 
     val isVerified: Boolean,
 

--- a/account/src/main/kotlin/com/project/indistraw/account/application/common/error/ErrorCode.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/application/common/error/ErrorCode.kt
@@ -14,10 +14,11 @@ enum class ErrorCode(
     // AUTH CODE
     AUTH_CODE_NOT_FOUND("인증 코드를 찾을 수 없습니다.", 404),
     AUTH_CODE_NOT_MATCH("인증 코드가 일치 하지 않습니다.", 400),
+    TOO_MANY_AUTH_CODE_REQUEST("인증 코드 확인 요청을 5번 초과 한 사용자 입니다.", 429),
 
     // AUTHENTICATION
     AUTHENTICATION_NOT_FOUND("인증되지 않은 사용자 입니다.", 404),
-    TOO_MANY_AUTHENTICATION_REQUEST("1시간 내에 최대 요청 5번을 초과한 사용자 입니다.", 429),
+    TOO_MANY_AUTHENTICATION_REQUEST("인증 메세지 요청을 5번 초과 한 사용자 입니다.", 429),
 
     // TOKEN
     INVALID_TOKEN("유효하지 않은 토큰입니다.", 401),

--- a/account/src/main/kotlin/com/project/indistraw/account/application/exception/TooManyAuthCodeRequestException.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/application/exception/TooManyAuthCodeRequestException.kt
@@ -1,0 +1,6 @@
+package com.project.indistraw.account.application.exception
+
+import com.project.indistraw.account.application.common.error.ErrorCode
+import com.project.indistraw.account.application.common.error.exception.IndiStrawAccountException
+
+class TooManyAuthCodeRequestException: IndiStrawAccountException(ErrorCode.TOO_MANY_AUTH_CODE_REQUEST)

--- a/account/src/main/kotlin/com/project/indistraw/account/application/port/output/QueryAuthenticationPort.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/application/port/output/QueryAuthenticationPort.kt
@@ -5,5 +5,6 @@ import com.project.indistraw.account.domain.Authentication
 interface QueryAuthenticationPort {
 
     fun findByPhoneNumberOrNull(phoneNumber: String): Authentication?
+    fun existsByPhoneNumber(phoneNumber: String): Boolean
 
 }

--- a/account/src/main/kotlin/com/project/indistraw/account/application/service/SendAuthCodeService.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/application/service/SendAuthCodeService.kt
@@ -1,8 +1,10 @@
 package com.project.indistraw.account.application.service
 
 import com.project.indistraw.account.application.common.annotation.ServiceWithTransaction
+import com.project.indistraw.account.application.exception.TooManyAuthenticationRequestException
 import com.project.indistraw.account.application.port.input.SendAuthCodeUseCase
 import com.project.indistraw.account.application.port.output.CommandAuthCodePort
+import com.project.indistraw.account.application.port.output.QueryAuthenticationPort
 import com.project.indistraw.account.application.port.output.SendMessagePort
 import com.project.indistraw.account.domain.AuthCode
 import com.project.indistraw.account.domain.Authentication
@@ -14,12 +16,25 @@ import java.util.*
 class SendAuthCodeService(
     private val sendMessagePort: SendMessagePort,
     private val commandAuthCodePort: CommandAuthCodePort,
+    private val queryAuthenticationPort: QueryAuthenticationPort,
     private val publisher: ApplicationEventPublisher
 ): SendAuthCodeUseCase {
 
     override fun execute(phoneNumber: String) {
+        val isExistsAuthentication = queryAuthenticationPort.existsByPhoneNumber(phoneNumber)
+
+        // 이미 authentication을 요청한 사용자가 5번 요청을 초과 할 시 예외처리 한다.
+        if (isExistsAuthentication) {
+            val authentication = queryAuthenticationPort.findByPhoneNumberOrNull(phoneNumber)
+            if (authentication!!.authenticationCount > 5) {
+                throw TooManyAuthenticationRequestException()
+            }
+            // 5번을 초과 하지 않았다면 attemptCount를 1 증가 시킨다.
+            publisher.publishEvent(CreateAuthenticationEvent(authentication.increaseAuthenticationCount()))
+        }
+
         val code = createCode()
-        // 요청받은 핸드폰 번호로 문자 발송
+        // 요청받은 핸드폰 번호로 문자를 발송한다.
         sendMessagePort.sendMessage(phoneNumber, code)
         val authCode = AuthCode(
             phoneNumber = phoneNumber,
@@ -27,8 +42,12 @@ class SendAuthCodeService(
             expiredAt = 300
         )
         commandAuthCodePort.saveAuthCode(authCode)
-        val authentication = Authentication(phoneNumber)
-        publisher.publishEvent(CreateAuthenticationEvent(authentication))
+
+        // authentication 없는 사용자는 authentication을 생성한다.
+        if (!isExistsAuthentication) {
+            val authentication = Authentication(phoneNumber)
+            publisher.publishEvent(CreateAuthenticationEvent(authentication))
+        }
     }
 
     private fun createCode() = Random().nextInt(8888) + 1111

--- a/account/src/main/kotlin/com/project/indistraw/account/application/service/SendAuthCodeService.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/application/service/SendAuthCodeService.kt
@@ -43,7 +43,7 @@ class SendAuthCodeService(
         )
         commandAuthCodePort.saveAuthCode(authCode)
 
-        // authentication 없는 사용자는 authentication을 생성한다.
+        // authentication이 없는 사용자는 authentication을 생성한다.
         if (!isExistsAuthentication) {
             val authentication = Authentication(phoneNumber)
             publisher.publishEvent(CreateAuthenticationEvent(authentication))

--- a/account/src/main/kotlin/com/project/indistraw/account/application/service/VerifyAuthCodeService.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/application/service/VerifyAuthCodeService.kt
@@ -1,10 +1,7 @@
 package com.project.indistraw.account.application.service
 
 import com.project.indistraw.account.application.common.annotation.ServiceWithTransaction
-import com.project.indistraw.account.application.exception.AuthCodeNotFoundException
-import com.project.indistraw.account.application.exception.AuthCodeNotMatchException
-import com.project.indistraw.account.application.exception.AuthenticationNotFoundException
-import com.project.indistraw.account.application.exception.TooManyAuthenticationRequestException
+import com.project.indistraw.account.application.exception.*
 import com.project.indistraw.account.application.port.input.VerifyAuthCodeUseCase
 import com.project.indistraw.account.application.port.output.QueryAuthCodePort
 import com.project.indistraw.account.application.port.output.QueryAuthenticationPort
@@ -24,10 +21,10 @@ class VerifyAuthCodeService(
         val authentication = queryAuthenticationPort.findByPhoneNumberOrNull(phoneNumber)
             ?: throw AuthenticationNotFoundException()
 
-        if (authentication.attemptCount > 5) throw TooManyAuthenticationRequestException()
+        if (authentication.authCodeCount > 5) throw TooManyAuthCodeRequestException()
 
         if (authCodeDomain.authCode != authCode) {
-            publisher.publishEvent(CreateAuthenticationEvent(authentication.increaseCount()))
+            publisher.publishEvent(CreateAuthenticationEvent(authentication.increaseAuthCodeCount()))
             throw AuthCodeNotMatchException()
         }
 

--- a/account/src/main/kotlin/com/project/indistraw/account/domain/Authentication.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/domain/Authentication.kt
@@ -2,37 +2,37 @@ package com.project.indistraw.account.domain
 
 data class Authentication(
     val phoneNumber: String,
-    val attemptCount: Long,
+    val authCodeCount: Long,
+    val authenticationCount: Long,
     val isVerified: Boolean,
     val expiredAt: Long
 ) {
 
     constructor(phoneNumber: String): this(
         phoneNumber = phoneNumber,
-        attemptCount = 0,
+        authCodeCount = 0,
+        authenticationCount = 0,
         isVerified = false,
         expiredAt = EXPIRED_AT
     )
 
     companion object {
-        const val MAX_ATTEMPT_COUNT = 5L
         const val EXPIRED_AT = 7200L
     }
 
-    fun increaseCount(): Authentication =
+    fun increaseAuthCodeCount(): Authentication =
         this.copy(
-            phoneNumber = phoneNumber,
-            attemptCount = attemptCount.inc(),
-            isVerified = isVerified,
-            expiredAt = expiredAt
+            authCodeCount = authCodeCount.inc()
+        )
+
+    fun increaseAuthenticationCount(): Authentication =
+        this.copy(
+            authenticationCount = authenticationCount.inc()
         )
 
     fun certified(): Authentication =
         this.copy(
-            phoneNumber = phoneNumber,
-            attemptCount = MAX_ATTEMPT_COUNT,
             isVerified = true,
-            expiredAt = expiredAt
         )
 
 }

--- a/account/src/main/kotlin/com/project/indistraw/global/event/CreateAuthenticationEventHandler.kt
+++ b/account/src/main/kotlin/com/project/indistraw/global/event/CreateAuthenticationEventHandler.kt
@@ -1,7 +1,6 @@
 package com.project.indistraw.global.event
 
 import com.project.indistraw.account.application.port.output.CommandAuthenticationPort
-import com.project.indistraw.account.domain.Authentication
 import mu.KotlinLogging
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
@@ -17,16 +16,7 @@ class CreateAuthenticationEventHandler(
     fun createAuthentication(createAuthenticationEvent: CreateAuthenticationEvent) {
         log.info("createAuthenticationEvent is activate")
 
-        val authentication = Authentication(
-            phoneNumber = createAuthenticationEvent.authentication.phoneNumber,
-            attemptCount = createAuthenticationEvent.authentication.attemptCount,
-            isVerified = createAuthenticationEvent.authentication.isVerified,
-            expiredAt = createAuthenticationEvent.authentication.expiredAt
-        )
-
-        log.info("attemptCount is " + authentication.attemptCount)
-
-        commandAuthenticationPort.saveAuthentication(authentication)
+        commandAuthenticationPort.saveAuthentication(createAuthenticationEvent.authentication)
     }
 
 }

--- a/account/src/main/kotlin/com/project/indistraw/global/event/DeleteAuthenticationEventHandler.kt
+++ b/account/src/main/kotlin/com/project/indistraw/global/event/DeleteAuthenticationEventHandler.kt
@@ -1,7 +1,6 @@
 package com.project.indistraw.global.event
 
 import com.project.indistraw.account.application.port.output.CommandAuthenticationPort
-import com.project.indistraw.account.domain.Authentication
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
@@ -18,14 +17,7 @@ class DeleteAuthenticationEventHandler(
     fun deleteAuthentication(deleteAuthenticationEvent: DeleteAuthenticationEvent) {
         log.info("deleteAuthenticationEvent is activate")
 
-        val authentication = Authentication(
-            phoneNumber = deleteAuthenticationEvent.authentication.phoneNumber,
-            attemptCount = deleteAuthenticationEvent.authentication.attemptCount,
-            isVerified = deleteAuthenticationEvent.authentication.isVerified,
-            expiredAt = deleteAuthenticationEvent.authentication.expiredAt
-        )
-
-        commandAuthenticationPort.deleteAuthentication(authentication)
+        commandAuthenticationPort.saveAuthentication(deleteAuthenticationEvent.authentication)
     }
 
 }

--- a/account/src/test/kotlin/com/project/indistraw/service/SendAuthCodeServiceTest.kt
+++ b/account/src/test/kotlin/com/project/indistraw/service/SendAuthCodeServiceTest.kt
@@ -1,10 +1,14 @@
 package com.project.indistraw.service
 
+import com.project.indistraw.account.application.exception.TooManyAuthenticationRequestException
 import com.project.indistraw.account.application.port.output.CommandAuthCodePort
+import com.project.indistraw.account.application.port.output.QueryAuthenticationPort
 import com.project.indistraw.account.application.port.output.SendMessagePort
 import com.project.indistraw.account.application.service.SendAuthCodeService
 import com.project.indistraw.account.domain.Authentication
+import com.project.indistraw.common.AnyValueObjectGenerator
 import com.project.indistraw.global.event.CreateAuthenticationEvent
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
@@ -14,8 +18,9 @@ import org.springframework.context.ApplicationEventPublisher
 class SendAuthCodeServiceTest: BehaviorSpec({
     val sendMessagePort = mockk<SendMessagePort>()
     val commandAuthCodePort = mockk<CommandAuthCodePort>()
+    val queryAuthenticationPort = mockk<QueryAuthenticationPort>()
     val publisher = mockk<ApplicationEventPublisher>()
-    val sendAuthCodeService = SendAuthCodeService(sendMessagePort, commandAuthCodePort, publisher)
+    val sendAuthCodeService = SendAuthCodeService(sendMessagePort, commandAuthCodePort, queryAuthenticationPort, publisher)
 
     Given("핸드폰 번호가 주어질때") {
         val phoneNumber = "01012345678"
@@ -25,12 +30,30 @@ class SendAuthCodeServiceTest: BehaviorSpec({
         every { sendMessagePort.sendMessage(any(), any()) } returns Unit
         every { publisher.publishEvent(CreateAuthenticationEvent(authentication)) } returns Unit
         every { commandAuthCodePort.saveAuthCode(any()) } returns code
+        every { queryAuthenticationPort.existsByPhoneNumber(phoneNumber) } returns false
+        every { queryAuthenticationPort.findByPhoneNumberOrNull(phoneNumber) } returns authentication
 
         When("authCode 발송 요청을 하면") {
             sendAuthCodeService.execute(phoneNumber)
 
             Then("authCode가 발송이 되어야 한다.") {
                 verify { sendMessagePort.sendMessage(any(), any()) }
+            }
+
+            Then("createAuthenticationEvent가 발생 되어야 한다.") {
+                verify { publisher.publishEvent(CreateAuthenticationEvent(authentication)) }
+            }
+        }
+
+        When("5번 초과 authCode 발송 요청을 하면") {
+            val overAuthentication = AnyValueObjectGenerator.anyValueObject<Authentication>("authenticationCount" to 6)
+            every { queryAuthenticationPort.existsByPhoneNumber(phoneNumber) } returns true
+            every { queryAuthenticationPort.findByPhoneNumberOrNull(phoneNumber) } returns overAuthentication
+
+            Then("TooManyAuthenticationRequestException이 터져야 한다.") {
+                shouldThrow<TooManyAuthenticationRequestException> {
+                    sendAuthCodeService.execute(phoneNumber)
+                }
             }
         }
     }


### PR DESCRIPTION
## 💡 개요
- 인증코드 확인 요청 5번 초과시 예외처리 로직 추가 하였습니다.
## 📃 작업사항
- 인증코드 확인 요청, 인증코드 발송 5번 초과 요청시 429 status를 반환하도록 예외처리를 하였습니다.
- 해당 로직에 관한 테스트 코드를 작성하였습니다.
## 🙋‍♂️ 리뷰내용
