### PR TITLE
🔀  :: coolsms 메세지 발송 실패시 예외 추가

### DIFF
--- a/account/src/main/kotlin/com/project/indistraw/account/adapter/output/message/CoolSmsAdapter.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/adapter/output/message/CoolSmsAdapter.kt
@@ -1,19 +1,20 @@
 package com.project.indistraw.account.adapter.output.message
 
+import com.project.indistraw.account.adapter.output.message.exception.MessageSendFailedException
 import com.project.indistraw.account.adapter.output.message.properties.CoolSmsProperties
 import com.project.indistraw.account.application.port.output.SendMessagePort
+import mu.KotlinLogging
 import net.nurigo.java_sdk.api.Message
 import net.nurigo.java_sdk.exceptions.CoolsmsException
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 
+private val log = KotlinLogging.logger {  }
 
 @Component
 class CoolSmsAdapter(
     private val coolSmsProperties: CoolSmsProperties
 ): SendMessagePort {
 
-    @Async
     override fun sendMessage(phoneNumber: String, authCode: Int) {
         val coolsms = Message(coolSmsProperties.access, coolSmsProperties.secret)
 
@@ -27,7 +28,8 @@ class CoolSmsAdapter(
         try {
             coolsms.send(params)
         } catch (e: CoolsmsException) {
-            throw IllegalArgumentException("메세지 발송에 실패하였습니다.")
+            log.error("coolsms message send failed")
+            throw MessageSendFailedException()
         }
     }
 

--- a/account/src/main/kotlin/com/project/indistraw/account/adapter/output/message/exception/MessageSendFailedException.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/adapter/output/message/exception/MessageSendFailedException.kt
@@ -1,0 +1,6 @@
+package com.project.indistraw.account.adapter.output.message.exception
+
+import com.project.indistraw.account.application.common.error.ErrorCode
+import com.project.indistraw.account.application.common.error.exception.IndiStrawAccountException
+
+class MessageSendFailedException: IndiStrawAccountException(ErrorCode.MESSAGE_SEND_FAILED)

--- a/account/src/main/kotlin/com/project/indistraw/account/application/common/error/ErrorCode.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/application/common/error/ErrorCode.kt
@@ -20,6 +20,9 @@ enum class ErrorCode(
     AUTHENTICATION_NOT_FOUND("인증되지 않은 사용자 입니다.", 404),
     TOO_MANY_AUTHENTICATION_REQUEST("인증 메세지 요청을 5번 초과 한 사용자 입니다.", 429),
 
+    // MESSAGE
+    MESSAGE_SEND_FAILED("coolsms 메세지 전송에 실패하였습니다.", 500),
+
     // TOKEN
     INVALID_TOKEN("유효하지 않은 토큰입니다.", 401),
     INVALID_TOKEN_TYPE("유효하지 않은 토큰 타입 입니다.", 401),


### PR DESCRIPTION
## 💡 개요
- coolsms 메세지 발송 실패시 예외 발생을 추가하였습니다.
## 📃 작업사항
- IllegalArgumentException에서 MessageSendFailedException를 발생시키도록 변경하였습니다.
## 🙋‍♂️ 리뷰내용
