### PR TITLE
🔀 :: 비밀번호 변경할때 기존 비밀번호와 새 비밀번호가 같을시 예외처리

### DIFF
--- a/account/src/main/kotlin/com/project/indistraw/account/application/common/enums/CheckPhoneNumberType.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/application/common/enums/CheckPhoneNumberType.kt
@@ -1,0 +1,7 @@
+package com.project.indistraw.account.application.common.enums
+
+enum class CheckPhoneNumberType {
+
+    SIGNUP, PASSWORD
+
+}

--- a/account/src/main/kotlin/com/project/indistraw/account/application/common/error/ErrorCode.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/application/common/error/ErrorCode.kt
@@ -10,6 +10,7 @@ enum class ErrorCode(
     DUPLICATE_ACCOUNT_ID("중복된 id 입니다.", 409),
     PASSWORD_NOT_MATCH("비밀번호가 일치하지 않습니다.", 400),
     ACCOUNT_NOT_FOUND("계정을 찾을 수 없습니다.", 404),
+    DUPLICATE_NEW_PASSWORD("기존 비밀번호와 같은 새 비밀번호 입니다.", 409),
 
     // AUTH CODE
     AUTH_CODE_NOT_FOUND("인증 코드를 찾을 수 없습니다.", 404),

--- a/account/src/main/kotlin/com/project/indistraw/account/application/exception/DuplicatedNewPasswordException.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/application/exception/DuplicatedNewPasswordException.kt
@@ -1,0 +1,6 @@
+package com.project.indistraw.account.application.exception
+
+import com.project.indistraw.account.application.common.error.ErrorCode
+import com.project.indistraw.account.application.common.error.exception.IndiStrawAccountException
+
+class DuplicatedNewPasswordException: IndiStrawAccountException(ErrorCode.DUPLICATE_NEW_PASSWORD)

--- a/account/src/main/kotlin/com/project/indistraw/account/application/service/UpdatePasswordService.kt
+++ b/account/src/main/kotlin/com/project/indistraw/account/application/service/UpdatePasswordService.kt
@@ -3,6 +3,7 @@ package com.project.indistraw.account.application.service
 import com.project.indistraw.account.application.common.annotation.ServiceWithTransaction
 import com.project.indistraw.account.application.common.util.AuthenticationValidator
 import com.project.indistraw.account.application.exception.AccountNotFoundException
+import com.project.indistraw.account.application.exception.DuplicatedNewPasswordException
 import com.project.indistraw.account.application.port.input.UpdatePasswordUseCase
 import com.project.indistraw.account.application.port.input.dto.UpdatePasswordDto
 import com.project.indistraw.account.application.port.output.CommandAccountPort
@@ -23,6 +24,10 @@ class UpdatePasswordService(
     override fun execute(dto: UpdatePasswordDto) {
         val account = queryAccountPort.findByPhoneNumberOrNull(dto.phoneNumber)
             ?: throw AccountNotFoundException()
+
+        if (passwordEncodePort.isPasswordMatch(dto.newPassword, account.encodedPassword)) {
+            throw DuplicatedNewPasswordException()
+        }
 
         val authentication = authenticationValidator.verifyAuthenticationByPhoneNumber(account.phoneNumber)
         publisher.publishEvent(DeleteAuthenticationEvent(authentication))


### PR DESCRIPTION
## 💡 개요
- 비밀번호 변경할때 기존 비밀번호와 새 비밀번호가 같을시 예외처리 기능을 추가하였습니다.
## 📃 작업사항
- 비밀번호 변경할때 기존 비밀번호와 새 비밀번호로  isPasswordMatch true일시 예외처리를 하였습니다.
## 🙋‍♂️ 리뷰내용
