### PR TITLE
gradle build와 clean build 부분 분활

### DIFF
--- a/.github/workflows/Spring-CI.yml
+++ b/.github/workflows/Spring-CI.yml
@@ -35,11 +35,9 @@ jobs:
       with:
         arguments: build
       
-      
     - name: Gradle clean and Build  
       run: ./gradlew clean build
       
-    
     - name: CI Discord Spring Success Notification
       uses: sarisia/actions-status-discord@v1
       if: ${{ success() }}

--- a/.github/workflows/Spring-CI.yml
+++ b/.github/workflows/Spring-CI.yml
@@ -34,8 +34,10 @@ jobs:
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       with:
         arguments: build
-      run:  | 
-        ./gradlew clean build
+      
+      
+    - name: Gradle clean and Build  
+      run: ./gradlew clean build
       
     
     - name: CI Discord Spring Success Notification


### PR DESCRIPTION
## 💡 개요
## 📃 작업사항
Spring-CI.yml 파일의 33번째 줄의 Gradle 빌드 부분에서  uses와 run이 동시에 사용되서 오류가 발생한것 같아서 uses와 run 코드를 분활하였습니다.
## 🙋‍♂️ 리뷰내용
