### PR TITLE
🔀 :: Spring-CI 스크립트 각 서버마다 실행

### DIFF
--- a/.github/workflows/Spring-Account-CI.yml
+++ b/.github/workflows/Spring-Account-CI.yml
@@ -2,7 +2,7 @@ name: Spring-Account CI
 
 on:
   push:
-    branches: [ "main", "Spring-Account" ]
+    branches: [ "main", "Spring" ]
   pull_request:
     branches: [ "Spring", "Spring-Account" ]
     
@@ -40,19 +40,19 @@ jobs:
     - name: Gradle clean and Build  
       run: ./gradlew clean build
       
-    - name: CI Discord Spring Success Notification
+    - name: Spring-Account CI Success Discord Notification
       uses: sarisia/actions-status-discord@v1
       if: ${{ success() }}
       with:
-        title: ✅ Spring CI success ✅
+        title: ✅ Spring-Account CI success ✅
         webhook: ${{ secrets.DISCORD_WEBHOOK }}
         color: 00FF00
     
-    - name:  CI Discord Spring Failed Notification
+    - name: Spring-Account CI Failed Discord Notification
       uses: sarisia/actions-status-discord@v1
       if: ${{ failure() }}
       with:
-        title: ❗️  Spring CI failed ❗️
+        title: ❗️ Spring-Account CI failed ❗️
         webhook: ${{ secrets.DISCORD_WEBHOOK }}
         color: FF0000
       

--- a/.github/workflows/Spring-Account-CI.yml
+++ b/.github/workflows/Spring-Account-CI.yml
@@ -1,10 +1,10 @@
-name: Spring CI
+name: Spring-Account CI
 
 on:
   push:
-    branches: [ "main", "Spring" ]
+    branches: [ "main", "Spring-Account" ]
   pull_request:
-    branches: [ "Spring-Account", "Spring" ]
+    branches: [ "Spring", "Spring-Account" ]
     
 permissions:
   contents: read
@@ -12,6 +12,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      working-directory: ./account
     steps:
     - name : Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/Spring-Crowdfunding-CI.yml
+++ b/.github/workflows/Spring-Crowdfunding-CI.yml
@@ -1,8 +1,8 @@
-name: Spring-Account CI
+name: Spring-Crowdfunding CI
 
 on:
   push:
-    branches: [ "main", "Spring-Crowdfunding" ]
+    branches: [ "main", "Spring" ]
   pull_request:
     branches: [ "Spring", "Spring-Crowdfunding" ]
     
@@ -40,18 +40,18 @@ jobs:
     - name: Gradle clean and Build  
       run: ./gradlew clean build
       
-    - name: CI Discord Spring Success Notification
+    - name: Spring-Crowdfunding CI Success Discord Notification
       uses: sarisia/actions-status-discord@v1
       if: ${{ success() }}
       with:
-        title: ✅ Spring CI success ✅
+        title: ✅ Spring-Crowdfunding CI success ✅
         webhook: ${{ secrets.DISCORD_WEBHOOK }}
         color: 00FF00
     
-    - name:  CI Discord Spring Failed Notification
+    - name: Spring-Crowdfunding CI Success Discord Notification
       uses: sarisia/actions-status-discord@v1
       if: ${{ failure() }}
       with:
-        title: ❗️  Spring CI failed ❗️
+        title: ❗️ Spring-Crowdfunding CI failed ❗️
         webhook: ${{ secrets.DISCORD_WEBHOOK }}
         color: FF0000

--- a/.github/workflows/Spring-Crowdfunding-CI.yml
+++ b/.github/workflows/Spring-Crowdfunding-CI.yml
@@ -1,0 +1,57 @@
+name: Spring-Account CI
+
+on:
+  push:
+    branches: [ "main", "Spring-Crowdfunding" ]
+  pull_request:
+    branches: [ "Spring", "Spring-Crowdfunding" ]
+    
+permissions:
+  contents: read
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./crowdfunding
+    steps:
+    - name : Checkout code
+      uses: actions/checkout@v3
+    
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+        
+    - name: Set up JDK 11 job success
+      if: ${{success()}}
+      run: echo "JDK 11 job succeeded"
+      
+    - name: Setup Gradle's permission
+      run : chmod +x gradlew
+    
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      with:
+        arguments: build
+      
+    - name: Gradle clean and Build  
+      run: ./gradlew clean build
+      
+    - name: CI Discord Spring Success Notification
+      uses: sarisia/actions-status-discord@v1
+      if: ${{ success() }}
+      with:
+        title: ✅ Spring CI success ✅
+        webhook: ${{ secrets.DISCORD_WEBHOOK }}
+        color: 00FF00
+    
+    - name:  CI Discord Spring Failed Notification
+      uses: sarisia/actions-status-discord@v1
+      if: ${{ failure() }}
+      with:
+        title: ❗️  Spring CI failed ❗️
+        webhook: ${{ secrets.DISCORD_WEBHOOK }}
+        color: FF0000


### PR DESCRIPTION
## 💡 개요
- Spring-CI 스크립트를 각 서버마다 실행하도록 변경하였습니다.
## 📃 작업사항
- Spring-CI에서 gradle을 권한 줄때 최상위 디렉토리여서 gradle을 못 읽는 현상이 발생해,
각 서브 디렉토리 마다 CI 스크립트를 실행하도록 변경하였습니다.
## 🙋‍♂️ 리뷰내용
- 각 디렉토리로 이동해서 CI 스크립트를 실행하도록 구현해봤는데 잘 돌아갈지 의문이라 이 부분 중심으로 리뷰 해주시면 감사하겠습니다.