### PR TITLE
🔀 :: 401, 403, 404 처리 로직 추가

### DIFF
--- a/crowdfunding/src/main/kotlin/com/project/indistraw/global/security/config/SecurityConfig.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/global/security/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package com.project.indistraw.global.security.config
 
+import com.project.indistraw.global.security.handler.CustomAccessDeniedHandler
 import com.project.indistraw.global.security.handler.CustomAuthenticationEntryPoint
 import com.project.indistraw.global.security.token.TokenParser
 import com.project.indistraw.global.security.token.common.emums.Authority
@@ -39,10 +40,13 @@ class SecurityConfig(
             // /health
             .mvcMatchers(HttpMethod.GET, "/").permitAll()
 
-            .anyRequest().denyAll()
+            .anyRequest().authenticated()
             .and()
 
             .exceptionHandling()
+            .accessDeniedHandler(CustomAccessDeniedHandler())
+            .and()
+            .httpBasic()
             .authenticationEntryPoint(CustomAuthenticationEntryPoint())
             .and()
 

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/global/security/handler/CustomAccessDeniedHandler.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/global/security/handler/CustomAccessDeniedHandler.kt
@@ -1,0 +1,18 @@
+package com.project.indistraw.global.security.handler
+
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class CustomAccessDeniedHandler: AccessDeniedHandler {
+
+    override fun handle(
+        request: HttpServletRequest?,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException?
+    ) {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN)
+    }
+
+}


### PR DESCRIPTION
## 💡 개요
## 📃 작업사항
- account 서버와 같이 accessDenidedHandler 클래스를 만들어 401, 403, 404 처리 로직을 구현하였습니다.
## 🙋‍♂️ 리뷰내용
