### PR TITLE
🔀 :: PayInfo 추가

### DIFF
--- a/crowdfunding/build.gradle.kts
+++ b/crowdfunding/build.gradle.kts
@@ -76,6 +76,9 @@ dependencies {
 	/* RabbitMQ */
 	implementation("org.springframework.boot:spring-boot-starter-amqp")
 	testImplementation("org.springframework.amqp:spring-rabbit-test")
+
+	/* boot pay */
+	implementation("io.github.bootpay:backend:2.1.4")
 }
 
 tasks.withType<KotlinCompile> {

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/pay/property/BootPayProperties.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/pay/property/BootPayProperties.kt
@@ -1,0 +1,11 @@
+package com.project.indistraw.crowdfunding.adapter.output.pay.property
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties("bootpay")
+class BootPayProperties(
+    val restApplicationId: String,
+    val privateKey: String
+)

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/CommandPayInfoPersistenceAdapter.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/CommandPayInfoPersistenceAdapter.kt
@@ -1,0 +1,25 @@
+package com.project.indistraw.crowdfunding.adapter.output.persistence
+
+import com.project.indistraw.crowdfunding.adapter.output.persistence.common.converter.PayInfoConverter
+import com.project.indistraw.crowdfunding.adapter.output.persistence.repository.PayInfoRepository
+import com.project.indistraw.crowdfunding.application.port.output.CommandPayInfoPort
+import com.project.indistraw.crowdfunding.domain.PayInfo
+import org.springframework.stereotype.Component
+
+@Component
+class CommandPayInfoPersistenceAdapter(
+    private val payInfoConverter: PayInfoConverter,
+    private val payInfoRepository: PayInfoRepository
+): CommandPayInfoPort {
+
+    override fun savePayInfo(payInfo: PayInfo) {
+        val payInfoEntity = payInfoConverter toEntity  payInfo
+        payInfoRepository.save(payInfoEntity)
+    }
+
+    override fun deletePayInfo(payInfo: PayInfo) {
+        val payInfoEntity = payInfoConverter toEntity  payInfo
+        payInfoRepository.delete(payInfoEntity)
+    }
+
+}

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/CommandRewardPersistenceAdapter.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/CommandRewardPersistenceAdapter.kt
@@ -1,6 +1,6 @@
 package com.project.indistraw.crowdfunding.adapter.output.persistence
 
-import com.project.indistraw.crowdfunding.adapter.output.persistence.common.converter.RewordConverter
+import com.project.indistraw.crowdfunding.adapter.output.persistence.common.converter.RewardConverter
 import com.project.indistraw.crowdfunding.adapter.output.persistence.repository.RewardRepository
 import com.project.indistraw.crowdfunding.application.port.output.CommandRewordPort
 import com.project.indistraw.crowdfunding.domain.Reward
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class CommandRewardPersistenceAdapter(
-    private val rewordConverter: RewordConverter,
+    private val rewordConverter: RewardConverter,
     private val rewardRepository: RewardRepository
 ): CommandRewordPort {
 

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/QueryRewardPersistenceAdapter.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/QueryRewardPersistenceAdapter.kt
@@ -1,6 +1,6 @@
 package com.project.indistraw.crowdfunding.adapter.output.persistence
 
-import com.project.indistraw.crowdfunding.adapter.output.persistence.common.converter.RewordConverter
+import com.project.indistraw.crowdfunding.adapter.output.persistence.common.converter.RewardConverter
 import com.project.indistraw.crowdfunding.adapter.output.persistence.repository.CrowdfundingRepository
 import com.project.indistraw.crowdfunding.adapter.output.persistence.repository.RewardRepository
 import com.project.indistraw.crowdfunding.application.exception.CrowdfundingNotFoundException
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class QueryRewardPersistenceAdapter(
-    private val rewordConverter: RewordConverter,
+    private val rewordConverter: RewardConverter,
     private val crowdfundingRepository: CrowdfundingRepository,
     private val rewardRepository: RewardRepository
 ): QueryRewardPort {

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/GenericConverter.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/GenericConverter.kt
@@ -1,0 +1,9 @@
+package com.project.indistraw.crowdfunding.adapter.output.persistence.common
+
+interface GenericConverter<D, E> {
+
+    infix fun toEntity(domain: D): E
+
+    infix fun toDomain(entity: E?): D?
+
+}

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/converter/PayInfoConverter.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/converter/PayInfoConverter.kt
@@ -1,0 +1,27 @@
+package com.project.indistraw.crowdfunding.adapter.output.persistence.common.converter
+
+import com.project.indistraw.crowdfunding.adapter.output.persistence.common.GenericConverter
+import com.project.indistraw.crowdfunding.adapter.output.persistence.entity.PayInfoEntity
+import com.project.indistraw.crowdfunding.domain.PayInfo
+import org.springframework.stereotype.Component
+
+@Component
+class PayInfoConverter: GenericConverter<PayInfo, PayInfoEntity> {
+
+    override infix fun toEntity(domain: PayInfo): PayInfoEntity =
+        domain.let {
+            PayInfoEntity(
+                id = it.receiptId,
+                accountIdx = it.accountIdx
+            )
+        }
+
+    override infix fun toDomain(entity: PayInfoEntity?): PayInfo? =
+        entity?.let {
+            PayInfo(
+                receiptId = it.id,
+                accountIdx = it.accountIdx
+            )
+        }
+
+}

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/converter/RewardConverter.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/converter/RewardConverter.kt
@@ -8,7 +8,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
-class RewordConverter(
+class RewardConverter(
     private val crowdfundingRepository: CrowdfundingRepository
 ) {
 

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/entity/BaseIdxEntity.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/entity/BaseIdxEntity.kt
@@ -6,7 +6,7 @@ import javax.persistence.Id
 import javax.persistence.MappedSuperclass
 
 @MappedSuperclass
-class BaseIdxEntity(
+abstract class BaseIdxEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val idx: Long

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/entity/BaseTimeEntity.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/entity/BaseTimeEntity.kt
@@ -1,0 +1,19 @@
+package com.project.indistraw.crowdfunding.adapter.output.persistence.common.entity
+
+import org.springframework.data.annotation.LastModifiedDate
+import java.time.LocalDateTime
+import javax.persistence.Column
+import javax.persistence.MappedSuperclass
+
+@MappedSuperclass
+abstract class BaseTimeEntity(
+    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    val createdDate: LocalDateTime = LocalDateTime.now(),
+
+    @LastModifiedDate
+    @Column(nullable = false, columnDefinition = "DATETIME(6)")
+    val modifiedAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(nullable = true, updatable = false, columnDefinition = "DATETIME(6)")
+    val deletedAt: LocalDateTime? = null
+)

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/entity/BaseUUIDEntity.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/common/entity/BaseUUIDEntity.kt
@@ -1,0 +1,17 @@
+package com.project.indistraw.crowdfunding.adapter.output.persistence.common.entity
+
+import org.hibernate.annotations.GenericGenerator
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.GeneratedValue
+import javax.persistence.Id
+import javax.persistence.MappedSuperclass
+
+@MappedSuperclass
+abstract class BaseUUIDEntity(
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name="uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)", nullable = false)
+    val accountIdx: UUID
+): BaseTimeEntity()

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/entity/PayInfoEntity.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/entity/PayInfoEntity.kt
@@ -1,0 +1,14 @@
+package com.project.indistraw.crowdfunding.adapter.output.persistence.entity
+
+import com.project.indistraw.crowdfunding.adapter.output.persistence.common.entity.BaseTimeEntity
+import org.springframework.data.redis.core.RedisHash
+import java.util.*
+import javax.persistence.Id
+
+@RedisHash
+data class PayInfoEntity(
+    @Id
+    val id: String,
+
+    val accountIdx: UUID
+): BaseTimeEntity()

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/repository/PayInfoRepository.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/adapter/output/persistence/repository/PayInfoRepository.kt
@@ -1,0 +1,7 @@
+package com.project.indistraw.crowdfunding.adapter.output.persistence.repository
+
+import com.project.indistraw.crowdfunding.adapter.output.persistence.entity.PayInfoEntity
+import org.springframework.data.repository.CrudRepository
+import java.util.*
+
+interface PayInfoRepository: CrudRepository<PayInfoEntity, UUID>

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/application/port/input/CreatePayInfoUseCase.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/application/port/input/CreatePayInfoUseCase.kt
@@ -1,0 +1,7 @@
+package com.project.indistraw.crowdfunding.application.port.input
+
+interface CreatePayInfoUseCase {
+
+    fun execute(): String
+
+}

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/application/port/output/CommandPayInfoPort.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/application/port/output/CommandPayInfoPort.kt
@@ -1,0 +1,10 @@
+package com.project.indistraw.crowdfunding.application.port.output
+
+import com.project.indistraw.crowdfunding.domain.PayInfo
+
+interface CommandPayInfoPort {
+
+    fun savePayInfo(payInfo: PayInfo)
+    fun deletePayInfo(payInfo: PayInfo)
+
+}

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/application/service/CreatePayInfoService.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/application/service/CreatePayInfoService.kt
@@ -1,0 +1,35 @@
+package com.project.indistraw.crowdfunding.application.service
+
+import com.project.indistraw.crowdfunding.application.common.annotation.ServiceWithTransaction
+import com.project.indistraw.crowdfunding.application.port.input.CreatePayInfoUseCase
+import com.project.indistraw.crowdfunding.application.port.output.AccountSecurityPort
+import com.project.indistraw.crowdfunding.application.port.output.CommandPayInfoPort
+import com.project.indistraw.crowdfunding.domain.PayInfo
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.*
+
+@ServiceWithTransaction
+class CreatePayInfoService(
+    private val commandPayInfoPort: CommandPayInfoPort,
+    private val accountSecurityPort: AccountSecurityPort
+): CreatePayInfoUseCase {
+
+    override fun execute(): String {
+        val currentAccountIdx = accountSecurityPort.getCurrentAccountIdx()
+        val payInfo = PayInfo(
+            receiptId = generateReceiptId(currentAccountIdx),
+            accountIdx = currentAccountIdx
+        )
+        commandPayInfoPort.savePayInfo(payInfo)
+        return payInfo.receiptId
+    }
+
+    private fun generateReceiptId(accountIdx: UUID): String {
+        val currentTime = LocalDateTime.now()
+        val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss")
+        val time = currentTime.format(dateFormatter).replace("-", "")
+        return "$time$accountIdx"
+    }
+
+}

--- a/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/domain/PayInfo.kt
+++ b/crowdfunding/src/main/kotlin/com/project/indistraw/crowdfunding/domain/PayInfo.kt
@@ -1,0 +1,8 @@
+package com.project.indistraw.crowdfunding.domain
+
+import java.util.UUID
+
+data class PayInfo(
+    val receiptId: String,
+    val accountIdx: UUID
+)

--- a/crowdfunding/src/main/resources/application.yml
+++ b/crowdfunding/src/main/resources/application.yml
@@ -33,3 +33,7 @@ jwt:
 
 account:
   serviceUrl: ${ACCOUNT_SERVICE_URL}
+
+bootpay:
+  restApplicationId: ${REST_APPLICATION_ID}
+  privateKey: ${PRIVATE_KEYee}


### PR DESCRIPTION
## 💡 개요
## 📃 작업사항
- receiptId, accountIdx를 영속화 하기 위한 PayInfo 도메인을 추가하였습니다.
## 🙋‍♂️ 리뷰내용
